### PR TITLE
fix(date-picker-month): invoke selectDate action with onclick

### DIFF
--- a/addon/templates/components/date-picker-month.hbs
+++ b/addon/templates/components/date-picker-month.hbs
@@ -17,7 +17,7 @@
         data-date-picker-day="{{date.year}}-{{date.month}}-{{date.day}}"
         disabled={{date.disabled}}
         class={{date-picker-day-classes 'date-picker__day' isDisabled=date.disabled isInRange=date.inRange isToday=(is-equal-day date.date today) isSelected=(is-equal-day date.date selectedDates)}}
-        {{action 'selectDate' date.date}}>
+        onclick={{action 'selectDate' date.date}}>
         {{date.day}}
       </button>
     {{else}}


### PR DESCRIPTION
In the context of wormholes, setting an action in this manner: ```<button {{action actionName}}```, will result in the action being ignored by the local context. Or at least, that the issue that I found, when using ```renderInPlace: false``` and a blocked-component. This PR resolved my issue.